### PR TITLE
Dev - Use `npm ci` instead of `npm install`

### DIFF
--- a/infra/docker/web.Dockerfile
+++ b/infra/docker/web.Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 # install dependencies
 COPY package*.json .
-RUN npm install
+RUN npm ci
 
 # build web application
 COPY . .


### PR DESCRIPTION
According to [official doc](https://docs.npmjs.com/cli/v11/commands/npm-ci), `npm ci` should be used in automated environment.

It ensures reproducible dependency installation is executed.
