### PR TITLE
Dev - add powershell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,21 @@ The aim is to build a minimalistic and production-ready online shop.
 - Product Listing Page
 
 ## Technologies
-- Terraform
-- Github Workflow
-- Docker
-- Powershell
-- ASP.NET
-- Typescript
-- React
-- React Router
-- Vite
-- ESLint
-- CSS Modules
+- DevOps
+  - Docker
+  - Github Workflow
+  - Terraform
+  - Webhook
+  - Powershell
+- Backend
+  - ASP.NET
+- Frontend
+  - Typescript
+  - React
+  - React Router
+  - Vite
+  - ESLint
+  - CSS Modules
 
 ## How to Run
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ The aim is to build a minimalistic and production-ready online shop.
 - Product Listing Page
 
 ## Technologies
+- Terraform
 - Github Workflow
 - Docker
+- Powershell
 - ASP.NET
 - Typescript
 - React
@@ -21,12 +23,14 @@ The aim is to build a minimalistic and production-ready online shop.
 
 ## How to Run
 
-```
-docker compose --file ./infra/docker/docker-compose.yaml up --build
-```
+| Command               | Description                                                                             |
+| ----------------------| --------------------------------------------------------------------------------------- |
+| `./run.ps1 prod`      | Start Docker containers in production mode.                                             |
+| `./run.ps1 stop`      | Stop Docker containers.                                                                 |
+| `./run.ps1 uninstall` | Remove all Docker resources related to this project.                                    |
 
-Then, go to http://localhost:5000/
+`prod` is hosted on http://localhost:5000.
 
 ## More Documentations
 
-[DevOps Infrastructure](./infra/README.md)
+- [DevOps Infrastructure](./infra/README.md)

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,28 @@
+#!pwsh
+param(
+  [Parameter(Position = 0, Mandatory = $true)]
+  [ValidateSet("prod", "stop", "uninstall")]
+  [string]$profile
+)
+
+function RunCommand([string]$command) {
+  Write-Host "Running the following command:"
+  Write-Host $command
+  Invoke-Expression $command
+}
+
+$compose = "docker compose --file ./infra/docker/docker-compose.yaml"
+switch ($profile) {
+  "prod" {
+    RunCommand("$compose down --rmi all --remove-orphans")
+    RunCommand("$compose build web")
+    RunCommand("$compose build app")
+    RunCommand("$compose up --detach")
+  }
+  "stop" {
+    RunCommand("$compose stop")
+  }
+  "uninstall" {
+    RunCommand("$compose down --rmi all --remove-orphans --volume")
+  }
+}


### PR DESCRIPTION
This PR adds a convenient Powershell script to build the project in production mode.
`web` needs to be built before `app` because the latter depends on the compiled output from the former.