### PR TITLE
Dev - Add e2e test as a required step before deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,10 +6,16 @@ on:
       - "main"
 
 jobs:
+  run-e2e-tests:
+    name: Run End-To-End Tests
+    uses: ./.github/workflows/e2e-tests.yaml
+    secrets: inherit
+
   publish-docker-images:
     name: Publish Docker Images
     uses: ./.github/workflows/publish-docker-images.yaml
     secrets: inherit
+      - run-e2e-tests
 
   trigger-deployment:
     name: Trigger Deployment


### PR DESCRIPTION
While e2e test is being run in PR checks, it can fail when the code is merged into `main`.
Therefore, adding the test as a step in the deployment pipeline.