### PR TITLE
Fix - Add another breakpoint for product list

### DIFF
--- a/web/src/components/molecules/ProductList.module.css
+++ b/web/src/components/molecules/ProductList.module.css
@@ -2,10 +2,18 @@
   width: fit-content;
 
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   gap: 1rem;
+
+  padding: 0;
+
+  @media(min-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
 
   @media(min-width: 1024px) {
     grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
   }
 }

--- a/web/src/components/pages/ProductListingPage.module.css
+++ b/web/src/components/pages/ProductListingPage.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  gap: 1rem;
 
   padding: 1rem;
 }

--- a/web/src/components/pages/ProductListingPage.module.css
+++ b/web/src/components/pages/ProductListingPage.module.css
@@ -3,7 +3,6 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 1rem;
 
   padding: 1rem;
 }


### PR DESCRIPTION
Currently, the narrowest size of product list is (240px * 2 + 1rem).
For screen size smaller than that, the product will be cropped.

This PR adds another breakpoint to display single-column products.
It is unlikely that there are screen size smaller than 240px.
