### PR TITLE
Fix - Update `Header` to use `Link` from React Router

### DIFF
--- a/web/src/components/molecules/Header.tsx
+++ b/web/src/components/molecules/Header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router";
 
 import { Logo } from "../atoms/Logo";
 import classes from "./Header.module.css";
@@ -6,10 +7,10 @@ import classes from "./Header.module.css";
 export const Header = () => {
   return (
     <header className={classes.container}>
-      <a href="/" className={classes.link}>
+      <Link to="/" className={classes.link}>
         <Logo />
         <span>Online Shop</span>
-      </a>
+      </Link>
     </header>
   );
 };


### PR DESCRIPTION
Currently, the link in the header will cause full page refresh.
This PR converts that to use `Link`, so it would be transition within the SPA.